### PR TITLE
Forgot to inherit secure property

### DIFF
--- a/SocketIOCocoa/EngineSocket.swift
+++ b/SocketIOCocoa/EngineSocket.swift
@@ -123,6 +123,7 @@ public class EngineSocket: Logger, EngineTransportDelegate{
             self.transports = transports
             self.query = query
             self.upgrade = upgrade
+            self.secure = secure
     }
     
     func createTransport(transportName: String) -> Transport? {


### PR DESCRIPTION
copy the secure property from the initializing class instead of always defaulting to false
